### PR TITLE
Fix a typo in STORv10

### DIFF
--- a/infinity/formats/stor_v10.py
+++ b/infinity/formats/stor_v10.py
@@ -302,4 +302,4 @@ class STOR_V10_Format (Format):
 
 
         
-register_format (STOR_V10_Format, signature='STOR V1.0')
+register_format (STOR_V10_Format, signature='STORV1.0')


### PR DESCRIPTION
Fix a typo in STORv10 that prevents its proper registration and display
