### PR TITLE
Fix bare 'except:' to catch IOError specifically in read_command_file

### DIFF
--- a/iesh
+++ b/iesh
@@ -153,7 +153,7 @@ def read_command_file (filename):
     """Read commands to be executed from a file."""
 
     try: fh = open (filename)
-    except: return False
+    except IOError: return False
 
     commands.extend (map (lambda s: s.rstrip ("\n\r"), fh.readlines ()))
 


### PR DESCRIPTION
Changes the bare `except: return False` in `read_command_file()` to `except IOError: return False`, ensuring only file I/O errors are silently handled rather than all exceptions.

https://buymeacoffee.com/muhamedfazalps